### PR TITLE
Fix workflow trigger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,7 @@ name: Publish
 on:
   pull_request:
     branches: [master]
+    types: [closed]
 
 env:
   FLUTTER_VERSION: 3.3.0


### PR DESCRIPTION
We should set `types` to `closed` if we want the workflow to run when the PR is merged