### PR TITLE
Make run android

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.karte.tracker_sample"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
# Summary
   - https://github.com/plaidev/karte-flutter-tools/issues/16

# Implementation

# Test plan

# Other Information

- example プロジェクトをflutter run コマンドから android をビルドできるように下記変更をしました
  - compileSdkVersion を 34 に変更しました
  - kotlin version を 1.7.0 に変更しました
