### PR TITLE
flutter 3.29に対応するため、registerWithを削除

### DIFF
--- a/karte_core/android/src/main/java/io/karte/flutter/core/KarteCorePlugin.java
+++ b/karte_core/android/src/main/java/io/karte/flutter/core/KarteCorePlugin.java
@@ -61,27 +61,6 @@ public class KarteCorePlugin implements FlutterPlugin, ActivityAware, MethodCall
     }
     //endregion
 
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(PluginRegistry.Registrar registrar) {
-        MethodChannel channel = new MethodChannel(registrar.messenger(), "karte_core");
-        channel.setMethodCallHandler(new KarteCorePlugin());
-        registrar.addNewIntentListener(new PluginRegistry.NewIntentListener() {
-            @Override
-            public boolean onNewIntent(@NonNull Intent intent) {
-                KarteApp.onNewIntent(intent);
-                return false;
-            }
-        });
-    }
-
     //region MethodCallHandler
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {


### PR DESCRIPTION
# Summary
   - related issue number
fix #48 
flutter 3.29 AndroidのPluginRegistry.Registrarが廃止されましたので、buildできないになっています
# Implementation

# Test plan

# Other Information