### PR TITLE
Flutter 3.29に対応するため、registerWithを削除

### DIFF
--- a/karte_core/android/src/main/java/io/karte/flutter/core/KarteCorePlugin.java
+++ b/karte_core/android/src/main/java/io/karte/flutter/core/KarteCorePlugin.java
@@ -61,27 +61,6 @@ public class KarteCorePlugin implements FlutterPlugin, ActivityAware, MethodCall
     }
     //endregion
 
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(PluginRegistry.Registrar registrar) {
-        MethodChannel channel = new MethodChannel(registrar.messenger(), "karte_core");
-        channel.setMethodCallHandler(new KarteCorePlugin());
-        registrar.addNewIntentListener(new PluginRegistry.NewIntentListener() {
-            @Override
-            public boolean onNewIntent(@NonNull Intent intent) {
-                KarteApp.onNewIntent(intent);
-                return false;
-            }
-        });
-    }
-
     //region MethodCallHandler
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {

--- a/karte_in_app_messaging/android/src/main/java/io/karte/flutter/inappmessaging/KarteInAppMessagingPlugin.java
+++ b/karte_in_app_messaging/android/src/main/java/io/karte/flutter/inappmessaging/KarteInAppMessagingPlugin.java
@@ -22,7 +22,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.karte.android.core.logger.Logger;
 import io.karte.android.inappmessaging.InAppMessaging;
 
@@ -40,20 +39,6 @@ public class KarteInAppMessagingPlugin implements FlutterPlugin, MethodCallHandl
     public void onAttachedToEngine(@NonNull FlutterPlugin.FlutterPluginBinding flutterPluginBinding) {
         channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "karte_in_app_messaging");
         channel.setMethodCallHandler(this);
-    }
-
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(Registrar registrar) {
-        MethodChannel channel = new MethodChannel(registrar.messenger(), "karte_in_app_messaging");
-        channel.setMethodCallHandler(new KarteInAppMessagingPlugin());
     }
 
     @Override

--- a/karte_notification/android/src/main/java/io/karte/flutter/notifications/KarteNotificationPlugin.java
+++ b/karte_notification/android/src/main/java/io/karte/flutter/notifications/KarteNotificationPlugin.java
@@ -29,7 +29,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.karte.android.core.logger.Logger;
 import io.karte.android.notifications.KarteAttributes;
 import io.karte.android.notifications.MessageHandler;
@@ -51,22 +50,6 @@ public class KarteNotificationPlugin implements FlutterPlugin, MethodCallHandler
         channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "karte_notification");
         channel.setMethodCallHandler(this);
         context = flutterPluginBinding.getApplicationContext();
-    }
-
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(Registrar registrar) {
-        KarteNotificationPlugin plugin = new KarteNotificationPlugin();
-        MethodChannel channel = new MethodChannel(registrar.messenger(), "karte_notification");
-        channel.setMethodCallHandler(plugin);
-        plugin.context = registrar.context();
     }
 
     @Override

--- a/karte_variables/android/src/main/java/io/karte/flutter/variables/KarteVariablesPlugin.java
+++ b/karte_variables/android/src/main/java/io/karte/flutter/variables/KarteVariablesPlugin.java
@@ -33,7 +33,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.karte.android.core.logger.Logger;
 import io.karte.android.utilities.ExtensionsKt;
 import io.karte.android.variables.FetchCompletion;
@@ -54,21 +53,6 @@ public class KarteVariablesPlugin implements FlutterPlugin, MethodCallHandler {
     public void onAttachedToEngine(@NonNull FlutterPlugin.FlutterPluginBinding flutterPluginBinding) {
         channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "karte_variables");
         channel.setMethodCallHandler(this);
-    }
-
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(Registrar registrar) {
-        KarteVariablesPlugin plugin = new KarteVariablesPlugin();
-        MethodChannel channel = new MethodChannel(registrar.messenger(), "karte_variables");
-        channel.setMethodCallHandler(plugin);
     }
 
     @Override

--- a/karte_visual_tracking/android/src/main/java/io/karte/flutter/visual_tracking/KarteVisualTrackingPlugin.java
+++ b/karte_visual_tracking/android/src/main/java/io/karte/flutter/visual_tracking/KarteVisualTrackingPlugin.java
@@ -11,7 +11,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.karte.android.core.logger.Logger;
 import io.karte.android.visualtracking.BasicAction;
 import io.karte.android.visualtracking.ImageProvider;
@@ -30,21 +29,6 @@ public class KarteVisualTrackingPlugin implements FlutterPlugin, MethodCallHandl
     public void onAttachedToEngine(@NonNull FlutterPlugin.FlutterPluginBinding flutterPluginBinding) {
         channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "karte_visual_tracking");
         channel.setMethodCallHandler(this);
-    }
-
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(Registrar registrar) {
-        KarteVisualTrackingPlugin plugin = new KarteVisualTrackingPlugin();
-        MethodChannel channel = new MethodChannel(registrar.messenger(), "karte_visual_tracking");
-        channel.setMethodCallHandler(plugin);
     }
 
     @Override


### PR DESCRIPTION
# Summary
   - related issue number
   - #48 

flutter 3.29 AndroidのPluginRegistry.Registrarが廃止されましたので、buildできないになっています。

# Implementation

# Test plan

# Other Information